### PR TITLE
Add active and hover transitions to text inputs and buttons

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -13,6 +13,10 @@ body {
   overflow: hidden;
   margin: 0; }
 
+/* Remove dotted border on Firefox (http://stackoverflow.com/a/199319) */
+button::-moz-focus-inner {
+  border: 0; }
+
 .starwars section {
   position: absolute;
   top: 45%;
@@ -135,9 +139,12 @@ body {
   font-size: 50px;
   border: 0;
   background: transparent;
-  color: #ff6; }
-  #play:focus {
-    outline: none; }
+  color: #ff6;
+  text-shadow: none;
+  transition: text-shadow 0.5s ease-out;
+  outline: none; }
+  #play:focus, #play:hover {
+    text-shadow: -1px 1px 8px #45f500, 1px -1px 8px #45f500; }
 
 #form-starwars {
   display: none;
@@ -145,9 +152,14 @@ body {
   #form-starwars input, #form-starwars textarea {
     width: 100%;
     margin-bottom: 10px;
-    border: 1px solid #ff6;
+    padding: 0.25em;
+    border: 0.25em solid rgba(255, 255, 102, 0.2);
+    border-radius: 0.2em;
     background: black;
-    color: #ff6; }
+    color: #ff6;
+    transition: border-color 0.7s ease-out; }
+    #form-starwars input:active, #form-starwars input:focus, #form-starwars textarea:active, #form-starwars textarea:focus {
+      border-color: #ff6; }
   #form-starwars textarea {
     height: 230px; }
 

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -190,12 +190,13 @@ button::-moz-focus-inner {
   font-size: 50px;
   border: 0;
   background: transparent;
-  color: transparentize(#ff6, 0.8);
-  transition: color 0.7s ease-out;
+  color: #ff6;
+  text-shadow: none;
+  transition: text-shadow 0.5s ease-out;
   outline: none;
 
   &:focus, &:hover {
-    color: #ff6;
+    text-shadow: -1px 1px 8px #45f500, 1px -1px 8px #45f500;
   }
 }
 

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -34,6 +34,11 @@ body {
     margin: 0;
 }
 
+/* Remove dotted border on Firefox (http://stackoverflow.com/a/199319) */
+button::-moz-focus-inner {
+  border: 0;
+}
+
 .starwars {
 
   section {
@@ -185,9 +190,12 @@ body {
   font-size: 50px;
   border: 0;
   background: transparent;
-  color: #ff6;
-  &:focus {
-    outline:none;
+  color: transparentize(#ff6, 0.8);
+  transition: color 0.7s ease-out;
+  outline: none;
+
+  &:focus, &:hover {
+    color: #ff6;
   }
 }
 
@@ -195,12 +203,19 @@ body {
   display: none;
   width: 500px;
 
-  input,textarea{
+  input,textarea {
     width: 100%;
     margin-bottom: 10px;
-    border: 1px solid #ff6;
+    padding: 0.25em;
+    border: 0.25em solid transparentize(#ff6, 0.8);
+    border-radius: 0.2em;
     background: black;
     color: #ff6;
+    transition: border-color 0.7s ease-out;
+
+    &:active, &:focus {
+      border-color: #ff6;
+    }
   }
 
   textarea{


### PR DESCRIPTION
input borders and button borders are now more transparent, on hover:

![screenshot from 2015-12-26 16 09 22](https://cloud.githubusercontent.com/assets/5278570/12007434/66ea114c-abeb-11e5-88c7-c0eb4eb59676.png)

Borders become fully visible once active or focused:

![screenshot from 2015-12-26 16 12 55](https://cloud.githubusercontent.com/assets/5278570/12007454/390389b0-abec-11e5-9d14-83d07f095bc8.png)
